### PR TITLE
Pause in mission screens (#518)

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -55,6 +55,7 @@ General:
 * Updated the wormhole cloud effect.
 * Mouse flight sensitivity made configurable by editing the preferences file.
 * Implemented new ECM visual effect.
+* Pause and unpause game is now allowed in mission screens while docked.
 
 Expansion Pack Development:
 ===========================

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -4858,9 +4858,10 @@ static BOOL autopilot_pause;
 		// Pause game, 'p' key
 		exceptionContext = @"pause key";
 		if (([self checkKeyPress:n_key_pausebutton] || joyButtonState[BUTTON_PAUSE]) && (gui_screen != GUI_SCREEN_LONG_RANGE_CHART &&
-				gui_screen != GUI_SCREEN_MISSION && gui_screen != GUI_SCREEN_REPORT &&
+				gui_screen != GUI_SCREEN_REPORT &&
 				gui_screen != GUI_SCREEN_SAVE && gui_screen != GUI_SCREEN_KEYBOARD_ENTRY) )
 		{
+  			BOOL isMissionScreenWithTextEntry = gui_screen == GUI_SCREEN_MISSION && _missionTextEntry;
 			if (!pause_pressed)
 			{
 				if ([gameController isGamePaused])
@@ -4876,13 +4877,19 @@ static BOOL autopilot_pause;
 				}
 				else
 				{
-					saved_script_time = script_time;
-					[[UNIVERSE messageGUI] clear];
-					
-					[UNIVERSE pauseGame];	// 'paused' handler
+    				if (!isMissionScreenWithTextEntry)
+					{
+						saved_script_time = script_time;
+						[[UNIVERSE messageGUI] clear];
+						
+						[UNIVERSE pauseGame];	// 'paused' handler
+      				}
 				}
 			}
-			pause_pressed = YES;
+   			if (!isMissionScreenWithTextEntry)
+      		{
+				pause_pressed = YES;
+    		}
 		}
 		else
 		{


### PR DESCRIPTION
Pause in mission screens is now allowed when docked

There does not seem to be a reason why pause / unpause cannot be used in mission screens. Unpause should work even if the mission screen is in text entry mode for some reason. Note that this is for docked mission screens only, in-flight ones are not considered right now.